### PR TITLE
Overwrite Validation registration

### DIFF
--- a/Src/Library/Config/EndpointOptions.cs
+++ b/Src/Library/Config/EndpointOptions.cs
@@ -39,4 +39,15 @@ public class EndpointOptions
     /// </code>
     /// </summary>
     public Action<EndpointDefinition>? Configurator { internal get; set; }
+
+    /// <summary>
+    /// set to true if you'd like to define the validator used by an endpoint 
+    /// </summary>
+    /// <code>
+    /// app.UseFastEndpoints(c =>
+    /// {
+    ///    c.Endpoints.SkipValidatorDiscovery = true;
+    /// }
+    /// </code>
+    public bool SkipValidatorDiscovery { internal get; set; }
 }

--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -297,6 +297,13 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     protected void ScopedValidator() => Definition.ScopedValidator();
 
     /// <summary>
+    /// specify the validator that is used for this endpoint.
+    /// if you want to specify the validator for each endpoint you will have to set <see cref="EndpointOptions.SkipValidatorDiscovery"/> to true.
+    /// </summary>
+    /// <typeparam name="TValidator"></typeparam>
+    protected void Validator<TValidator>() => Definition.Validator<TValidator>();
+
+    /// <summary>
     /// specify an override route prefix for this endpoint if a global route prefix is enabled.
     /// this is ignored if a global route prefix is not configured.
     /// global prefix can be ignored by setting <c>string.Empty</c>

--- a/Src/Library/Endpoint/EndpointDefinition.cs
+++ b/Src/Library/Endpoint/EndpointDefinition.cs
@@ -265,6 +265,12 @@ public sealed class EndpointDefinition
     /// not specifying a header name will first look for 'X-Forwarded-For' header and if not present, will use `HttpContext.Connection.RemoteIpAddress`.
     /// </param>
     public void Throttle(int hitLimit, double durationSeconds, string? headerName = null) => HitCounter = new(headerName, durationSeconds, hitLimit);
+
+    /// <summary>
+    /// validator that should be used for this endpoint
+    /// </summary>
+    /// <typeparam name="TValidator">the validator that will be used by this endpoint</typeparam>
+    public void Validator<TValidator>() => ValidatorType = typeof(TValidator);
 }
 
 /// <summary>

--- a/Src/Library/Extensions/EndpointData.cs
+++ b/Src/Library/Extensions/EndpointData.cs
@@ -58,6 +58,8 @@ internal sealed class EndpointData
             "NJsonSchema",
             "Namotion"
         };
+        
+        var validationTypes = options?.CustomValidatorTypes ?? new [] { Types.IEndpointValidator} ;
 
         var discoveredTypes = options?.SourceGeneratorDiscoveredTypes ?? Enumerable.Empty<Type>();
 
@@ -77,6 +79,14 @@ internal sealed class EndpointData
             if (options?.AssemblyFilter is not null)
                 assemblies = assemblies.Where(options.AssemblyFilter);
 
+            var typesToRegister = new List<Type>() {
+                Types.IEndpoint,
+                Types.IEventHandler,
+                Types.ISummary
+            };
+            
+            typesToRegister.AddRange(validationTypes);
+            
             discoveredTypes = assemblies
                 .Where(a =>
                     !a.IsDynamic &&
@@ -86,12 +96,7 @@ internal sealed class EndpointData
                     !t.IsAbstract &&
                     !t.IsInterface &&
                     !t.IsGenericType &&
-                    t.GetInterfaces().Intersect(new[] {
-                        Types.IEndpoint,
-                        Types.IEndpointValidator,
-                        Types.IEventHandler,
-                        Types.ISummary
-                    }).Any());
+                    t.GetInterfaces().Intersect(typesToRegister).Any());
         }
 
         //Endpoint<TRequest>
@@ -118,7 +123,7 @@ internal sealed class EndpointData
                     continue;
                 }
 
-                if (tInterface == Types.IEndpointValidator)
+                if (validationTypes.Contains(tInterface))
                 {
                     var tRequest = t.GetGenericArgumentsOfType(Types.ValidatorOf1)?[0]!;
                     valDict.Add(tRequest, t);

--- a/Src/Library/Extensions/EndpointDiscoveryOptions.cs
+++ b/Src/Library/Extensions/EndpointDiscoveryOptions.cs
@@ -32,4 +32,10 @@ public class EndpointDiscoveryOptions
     /// doing so will use the types discovered during source generation instead of reflection based type discovery.
     /// </summary>
     public Type[]? SourceGeneratorDiscoveredTypes { get; set; }
+    
+    /// <summary>
+    /// an optional list to allow the definition of what types should be handled as a validator.
+    /// if no types are defined here only validators that inherit from <see cref="Validator{TRequest}"/> are registered.
+    /// </summary>
+    public Type[]? CustomValidatorTypes { get; set; }
 }


### PR DESCRIPTION
Allows to override the registration of validators by either:

- set a list of types to be registered as validators during configuration
- set the validator type for an endpoint in the `Configure` method