### PR TITLE
Add HTTP 429 and fix typo

### DIFF
--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -26,8 +26,9 @@ internal class OperationProcessor : IOperationProcessor
         { "401", "Unauthorized" },
         { "403", "Forbidden" },
         { "404", "Not Found" },
-        { "405", "Mehtod Not Allowed" },
+        { "405", "Method Not Allowed" },
         { "406", "Not Acceptable" },
+        { "429", "Too Many Requests" },
         { "500", "Server Error" },
     };
 


### PR DESCRIPTION
I assume this code changes the swagger description. The 429 is common and is used by the library itself with rate limiting, so I think it should be added here.

![bild](https://user-images.githubusercontent.com/35617441/189249802-71838dc1-c07c-482f-a48d-1adb288dae73.png)

I also fixed a typo in HTTP 405.

Haven't tested this, but I don't see why it wouldn't work.