### PR TITLE
Adds IEndpointFactory interception point

### DIFF
--- a/Src/Library/Endpoint/Auxiliary/EndpointFactory.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointFactory.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FastEndpoints;
+
+/// <summary>
+/// the default endpoint factory. it resolves the <see cref="EndpointDefinition.EndpointType"/> from the
+/// <see cref="HttpContext.RequestServices"/>. both constructor dependencies and property dependencies are injected.
+/// </summary>
+public class EndpointFactory : IEndpointFactory
+{
+    public BaseEndpoint Create(EndpointDefinition definition, HttpContext ctx)
+    {
+        var epInstance = (BaseEndpoint)ctx.RequestServices.GetRequiredService(definition.EndpointType);
+
+        for (var i = 0; i < definition.ServiceBoundEpProps?.Length; i++)
+        {
+            var prop = definition.ServiceBoundEpProps[i];
+            prop.PropSetter(epInstance, ctx.RequestServices.GetRequiredService(prop.PropType));
+        }
+
+        return epInstance;
+    }
+}

--- a/Src/Library/Endpoint/Endpoint.Base.cs
+++ b/Src/Library/Endpoint/Endpoint.Base.cs
@@ -9,6 +9,9 @@ using System.Runtime.CompilerServices;
 
 namespace FastEndpoints;
 
+/// <summary>
+/// the base class all fast endpoints inherit from
+/// </summary>
 public abstract class BaseEndpoint : IEndpoint
 {
     private List<ValidationFailure> _failures;

--- a/Src/Library/Extensions/ExecutorMiddleware.cs
+++ b/Src/Library/Extensions/ExecutorMiddleware.cs
@@ -61,6 +61,9 @@ internal class ExecutorMiddleware
 
             BaseEndpoint epInstance = factory.Create(endpoint, ctx);
 
+            epInstance.Definition = epDef;
+            epInstance.HttpContext = ctx;
+
             ResponseCacheExecutor.Execute(ctx, endpoint.Metadata.GetMetadata<ResponseCacheAttribute>());
 
             //terminate middleware here. we're done executing

--- a/Src/Library/Extensions/ExecutorMiddleware.cs
+++ b/Src/Library/Extensions/ExecutorMiddleware.cs
@@ -57,10 +57,9 @@ internal class ExecutorMiddleware
                 }
             }
 
-            var epInstance = (BaseEndpoint)ctx.RequestServices.GetRequiredService(epDef.EndpointType);
-            epInstance.Definition = epDef;
-            epInstance.HttpContext = ctx;
-            ResolveServices(epInstance, ctx.RequestServices, epDef.ServiceBoundEpProps);
+            var factory = ctx.RequestServices.GetRequiredService<IEndpointFactory>();
+
+            BaseEndpoint epInstance = factory.Create(endpoint, ctx);
 
             ResponseCacheExecutor.Execute(ctx, endpoint.Metadata.GetMetadata<ResponseCacheAttribute>());
 
@@ -69,17 +68,6 @@ internal class ExecutorMiddleware
         }
 
         return _next(ctx); //this is not a fastendpoint, let next middleware handle it
-    }
-
-    private static void ResolveServices(object epInstance, IServiceProvider services, ServiceBoundEpProp[]? props)
-    {
-        if (props is null) return;
-
-        for (var i = 0; i < props.Length; i++)
-        {
-            var p = props[i];
-            p.PropSetter(epInstance, services.GetRequiredService(p.PropType));
-        }
     }
 
     private static void ThrowAuthMiddlewareMissing(string epName)

--- a/Src/Library/Extensions/ExecutorMiddleware.cs
+++ b/Src/Library/Extensions/ExecutorMiddleware.cs
@@ -12,10 +12,12 @@ internal class ExecutorMiddleware
 {
     private const string authInvoked = "__AuthorizationMiddlewareWithEndpointInvoked";
     private const string corsInvoked = "__CorsMiddlewareWithEndpointInvoked";
+    private readonly IEndpointFactory _epFactory;
     private readonly RequestDelegate _next;
 
-    public ExecutorMiddleware(RequestDelegate next)
+    public ExecutorMiddleware(IEndpointFactory epFactory, RequestDelegate next)
     {
+        _epFactory = epFactory;
         _next = next ?? throw new ArgumentNullException(nameof(next));
     }
 
@@ -57,10 +59,7 @@ internal class ExecutorMiddleware
                 }
             }
 
-            var factory = ctx.RequestServices.GetRequiredService<IEndpointFactory>();
-
-            BaseEndpoint epInstance = factory.Create(endpoint, ctx);
-
+            var epInstance = _epFactory.Create(epDef, ctx);
             epInstance.Definition = epDef;
             epInstance.HttpContext = ctx;
 

--- a/Src/Library/Extensions/MainExtensions.cs
+++ b/Src/Library/Extensions/MainExtensions.cs
@@ -30,17 +30,18 @@ public static class MainExtensions
     /// </summary>
     /// <param name="options">optionally specify the endpoint discovery options</param>
     /// <param name="config">optionally specify the IConfiguration/ConfigurationManager if you need to access it from within endpoint Configure() method</param>
-    public static IServiceCollection AddFastEndpoints(this IServiceCollection services, Action<EndpointDiscoveryOptions>? options = null,
+    public static IServiceCollection AddFastEndpoints(this IServiceCollection services,
+        Action<EndpointDiscoveryOptions>? options = null,
         ConfigurationManager? config = null)
     {
         var opts = new EndpointDiscoveryOptions();
         options?.Invoke(opts);
         Endpoints = new(services, opts, config);
         services.AddAuthorization(BuildSecurityPoliciesForEndpoints); //this method doesn't block
-        services.AddHttpContextAccessor();
+        services.AddHttpContextAccessor(); //todo: remove after removing scoped validator support.
+        services.AddSingleton<IEndpointFactory, EndpointFactory>();
         services.TryAddSingleton(typeof(IRequestBinder<>), typeof(RequestBinder<>));
         services.AddSingleton(typeof(Event<>));
-        services.AddSingleton<IEndpointFactory, DefaultEndpointFactory>();
         return services;
     }
 

--- a/Src/Library/Extensions/MainExtensions.cs
+++ b/Src/Library/Extensions/MainExtensions.cs
@@ -40,6 +40,7 @@ public static class MainExtensions
         services.AddHttpContextAccessor();
         services.TryAddSingleton(typeof(IRequestBinder<>), typeof(RequestBinder<>));
         services.AddSingleton(typeof(Event<>));
+        services.AddSingleton<IEndpointFactory, DefaultEndpointFactory>();
         return services;
     }
 

--- a/Src/Library/Interfaces/IEndpoint.cs
+++ b/Src/Library/Interfaces/IEndpoint.cs
@@ -4,11 +4,19 @@ using System.Collections.Concurrent;
 
 namespace FastEndpoints;
 
-[HideFromDocs]
+/// <summary>
+/// the common interface implemented by all endpoints
+/// </summary>
 public interface IEndpoint
 {
+    /// <summary>
+    /// the http context of the current request
+    /// </summary>
     HttpContext HttpContext { get; } //this is for allowing consumers to write extension methods
 
+    /// <summary>
+    /// validation failures collection for the endpoint
+    /// </summary>
     List<ValidationFailure> ValidationFailures { get; } //also for extensibility
 
     //key: the type of the endpoint

--- a/Src/Library/Interfaces/IEndpointFactory.cs
+++ b/Src/Library/Interfaces/IEndpointFactory.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FastEndpoints;
+
+/// <summary>
+/// interface for the creation of endpoints.
+/// </summary>
+public interface IEndpointFactory
+{
+    BaseEndpoint Create(Endpoint endpoint, HttpContext ctx);
+}
+
+/// <summary>
+/// The default endpoint factory. It resolves the <see cref="EndpointDefinition.EndpointType"/> from the
+/// <see cref="HttpContext.RequestServices"/>. Both constructor dependencies and property dependencies are injected.
+/// </summary>
+public class DefaultEndpointFactory : IEndpointFactory
+{
+    public BaseEndpoint Create(Endpoint endpoint, HttpContext ctx)
+    {
+        var epDef = endpoint.Metadata.GetMetadata<EndpointDefinition>();
+        var epInstance = (BaseEndpoint)ctx.RequestServices.GetRequiredService(epDef!.EndpointType);
+        epInstance.Definition = epDef;
+        epInstance.HttpContext = ctx;
+        ResolveServices(epInstance, ctx.RequestServices, epDef.ServiceBoundEpProps);
+        return epInstance;
+    }
+
+    private static void ResolveServices(object epInstance, IServiceProvider services, ServiceBoundEpProp[]? props)
+    {
+        if (props is null) return;
+
+        for (var i = 0; i < props.Length; i++)
+        {
+            var p = props[i];
+            p.PropSetter(epInstance, services.GetRequiredService(p.PropType));
+        }
+    }
+}

--- a/Src/Library/Interfaces/IEndpointFactory.cs
+++ b/Src/Library/Interfaces/IEndpointFactory.cs
@@ -21,8 +21,6 @@ public class DefaultEndpointFactory : IEndpointFactory
     {
         var epDef = endpoint.Metadata.GetMetadata<EndpointDefinition>();
         var epInstance = (BaseEndpoint)ctx.RequestServices.GetRequiredService(epDef!.EndpointType);
-        epInstance.Definition = epDef;
-        epInstance.HttpContext = ctx;
         ResolveServices(epInstance, ctx.RequestServices, epDef.ServiceBoundEpProps);
         return epInstance;
     }

--- a/Src/Library/Interfaces/IEndpointFactory.cs
+++ b/Src/Library/Interfaces/IEndpointFactory.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace FastEndpoints;
 
@@ -8,31 +7,10 @@ namespace FastEndpoints;
 /// </summary>
 public interface IEndpointFactory
 {
-    BaseEndpoint Create(Endpoint endpoint, HttpContext ctx);
-}
-
-/// <summary>
-/// The default endpoint factory. It resolves the <see cref="EndpointDefinition.EndpointType"/> from the
-/// <see cref="HttpContext.RequestServices"/>. Both constructor dependencies and property dependencies are injected.
-/// </summary>
-public class DefaultEndpointFactory : IEndpointFactory
-{
-    public BaseEndpoint Create(Endpoint endpoint, HttpContext ctx)
-    {
-        var epDef = endpoint.Metadata.GetMetadata<EndpointDefinition>();
-        var epInstance = (BaseEndpoint)ctx.RequestServices.GetRequiredService(epDef!.EndpointType);
-        ResolveServices(epInstance, ctx.RequestServices, epDef.ServiceBoundEpProps);
-        return epInstance;
-    }
-
-    private static void ResolveServices(object epInstance, IServiceProvider services, ServiceBoundEpProp[]? props)
-    {
-        if (props is null) return;
-
-        for (var i = 0; i < props.Length; i++)
-        {
-            var p = props[i];
-            p.PropSetter(epInstance, services.GetRequiredService(p.PropType));
-        }
-    }
+    /// <summary>
+    /// returns the instantiated fast endpoint from a given <see cref="EndpointDefinition"/> and <see cref="HttpContext"/>
+    /// </summary>
+    /// <param name="definition">the endpoint definition for the current request</param>
+    /// <param name="ctx">the http context of the current request</param>
+    BaseEndpoint Create(EndpointDefinition definition, HttpContext ctx);
 }


### PR DESCRIPTION
This PR is related to the discussion #218 and adds:

* An `IEndpointFactory` abstraction for the creation (or interception) of `BaseEndpoint` instances.
* A `DefaultEndpointFactory` implementation that is used as default implementation of the FastEndpoints framework
* A singleton registration of `DefaultEndpointFactory` in the `AddFastEndpoints` extension method.

The `DefaultEndpointFactory` is both responsible for the created endpoint and the injection of any properties. Property injection should be part of the default implementation, because otherwise it consuming `ExecutorMiddleware` would possibly override any properties that are already injected by the default implementation.

The `DefaultEndpointFactory`, however, is *not* responsible for initialization of the endpoint instance; this is left to the `ExecutorMiddleware`. Letting the factory initialize the endpoint would force the `BaseEndpoint` `Definition` and `HttpContext` property setters to become public; which has possibly bigger design consequences.

The definition of the `IEndpointFactory` is chosen such, that its `Create` method is supplied with as much information as possible. This is why its signature is as follows:

``` c#
BaseEndpoint Create(Endpoint endpoint, HttpContext ctx)
```

By supplying the `Endpoint` instead of a `Type` it gives access to all metadata a custom implementation might want access to. It gives the largest amount of flexibility to someone who wishes to intercept the creation of endpoints.

Supplying `HttpContext` has the same advantages; it allows a custom implementation to base the created endpoint implementation on request-specific information. Another advantage is that it allows the `DefaultEndpointFactory` to be registered as a `Singleton`, as the `DefaultEndpointFactory` now can use the `HttpContext` to resolve request-based services from.

But even though the `DefaultEndpointFactory` is registered as a `Singleton`, the `ExecutorMiddleware` still resolves the `IEndpointFactory` on each request instead of caching it. This is deliberate, because it allows custom `IEndpointFactory` implementations to use another lifestyle. This allows scoped registrations to be injected into its constructor, without having to resolve them explicitly from the `HttpContext`. In other words, this again increases flexibility.

Downside of of letting the `ExecutorMiddleware` resolve the `IEndpointFactory` on each request is the theoretical loss of performance because of the extra invoked resolve. If this proves to be a too costly performance hit (which I actually doubt, as resolving a Singleton from MS.DI is reaally fast), you can also communicate through the `IEndpointFactory` documentation that custom implementations will be treated as `Singleton`. This allows you to cache resolve `IEndpointFactory` instance indefinitely.

Using this PR a Simple Injector user, for instance, would be able to integrate FastEndpoints with Simple Injector as follows:

``` c#
// Custom IEndpointFactory implementation
public record SimpleInjectorEndpointFactory(Container Container) : IEndpointFactory
{
    public BaseEndpoint Create(Endpoint endpoint, HttpContext ctx) =>
        Container.GetInstance(endpoint.Metadata.GetMetadata<EndpointDefinition>()!.EndpointType);
}

// Registration
var builder = WebApplication.CreateBuilder();
builder.Services
    .AddFastEndpoints()
    .AddSimpleInjector(container)
    .AddSingleton<IEndpointFactory, SimpleInjectorEndpointFactory>();
// etc
```